### PR TITLE
Atualiza lógica do presente para óculos com Clip

### DIFF
--- a/mini-cart-presente-clip
+++ b/mini-cart-presente-clip
@@ -303,7 +303,7 @@
 
           <!-- Verifica itens no carrinho -->
           {%- for line_item in cart.items -%}
-            {%- if line_item.product.title contains 'Clip' -%}
+            {%- if line_item.product.title contains 'Óculos' and line_item.product.title contains 'Clip' -%}
               {%- assign num_glasses = num_glasses | plus: line_item.quantity -%}
             {%- endif -%}
 


### PR DESCRIPTION
## Summary
- ajusta a contagem do brinde para considerar apenas óculos com "Clip" no nome

## Testing
- não aplicável


------
https://chatgpt.com/codex/tasks/task_e_68d5fd87d12883258dc714b4e0065884